### PR TITLE
fix: clamp caret rect height on empty lines to prevent unwanted scrolling

### DIFF
--- a/Sources/InfomaniakRichHTMLEditor/Resources/js/editor/selection.js
+++ b/Sources/InfomaniakRichHTMLEditor/Resources/js/editor/selection.js
@@ -57,7 +57,24 @@ function getCaretRect(anchorNode) {
         case 0:
             const node = anchorNode || window.getSelection().anchorNode;
             const closestParentElement = getClosestParentNodeElement(node);
-            return closestParentElement.getBoundingClientRect();
+            if (closestParentElement == null) {
+                return null;
+            }
+            const elementRect = closestParentElement.getBoundingClientRect();
+            // Clamp height to line height to prevent unwanted scrolling
+            // when the parent is a large container (e.g. the editor div).
+            const computedStyle = window.getComputedStyle(closestParentElement);
+            const lineHeight = parseFloat(computedStyle.lineHeight);
+            const fontSize = parseFloat(computedStyle.fontSize);
+            const effectiveHeight = !isNaN(lineHeight)
+                ? lineHeight
+                : (fontSize ? fontSize * 1.2 : elementRect.height);
+            return new DOMRect(
+                elementRect.x,
+                elementRect.y,
+                elementRect.width,
+                Math.min(elementRect.height, effectiveHeight)
+            );
         case 1:
             return rangeRects[0];
         default:

--- a/Sources/InfomaniakRichHTMLEditor/WebViewBridge/JavaScriptManager.swift
+++ b/Sources/InfomaniakRichHTMLEditor/WebViewBridge/JavaScriptManager.swift
@@ -68,7 +68,7 @@ final class JavaScriptManager {
     }
 
     func setCaretAtBeginningOfDocument() {
-        evaluate(function: .setCaretAtEndOfDocument)
+        evaluate(function: .setCaretAtBeginningOfDocument)
     }
 
     func setCaretAtEndOfDocument() {


### PR DESCRIPTION
This PR resolves an issue where setting the caret to an empty line triggered a scroll to the bottom. Additionally, if the HTML loaded into the editor began with an empty line, the editor would scroll to the bottom.

When getClientRects() returns 0 rects (empty lines with only <br>), the fallback used the parent element's full getBoundingClientRect(). If the parent is the editor div itself, this returns a rect covering the entire content area, causing scrollRectToVisible to scroll to the bottom.

Clamp the fallback rect height to the element's computed line height so the scroll target remains a single line.

Also fix setCaretAtBeginningOfDocument() which was incorrectly calling setCaretAtEndOfDocument.