### PR TITLE
Example of editor with SwiftUI toolbar

### DIFF
--- a/Examples/Example SwiftUI/Example SwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/Example SwiftUI/Example SwiftUI.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A768AFC92C5C36090055519D /* NotScrollableEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A768AFC82C5C36090055519D /* NotScrollableEditorView.swift */; };
 		A768AFCC2C5C37210055519D /* FixedSizeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A768AFCB2C5C37210055519D /* FixedSizeEditorView.swift */; };
 		A7C4A2A72F365F2B00AC6033 /* EditorWithToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C4A2A62F365F2B00AC6033 /* EditorWithToolbar.swift */; };
+		B76F396D2FB4638200C6F32F /* EditorWithSwiftUIToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76F396B2FB4619D00C6F32F /* EditorWithSwiftUIToolbar.swift */; };
 		F90560E82C47B8830015E813 /* InfomaniakRichHTMLEditor in Frameworks */ = {isa = PBXBuildFile; productRef = F90560E72C47B8830015E813 /* InfomaniakRichHTMLEditor */; };
 		F91EA2492C3D12B7007489BD /* Example_SwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91EA2482C3D12B7007489BD /* Example_SwiftUIApp.swift */; };
 		F91EA24B2C3D12B7007489BD /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91EA24A2C3D12B7007489BD /* RootView.swift */; };
@@ -35,6 +36,7 @@
 		A768AFC82C5C36090055519D /* NotScrollableEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotScrollableEditorView.swift; sourceTree = "<group>"; };
 		A768AFCB2C5C37210055519D /* FixedSizeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSizeEditorView.swift; sourceTree = "<group>"; };
 		A7C4A2A62F365F2B00AC6033 /* EditorWithToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorWithToolbar.swift; sourceTree = "<group>"; };
+		B76F396B2FB4619D00C6F32F /* EditorWithSwiftUIToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorWithSwiftUIToolbar.swift; sourceTree = "<group>"; };
 		F91EA2452C3D12B7007489BD /* Example SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91EA2482C3D12B7007489BD /* Example_SwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example_SwiftUIApp.swift; sourceTree = "<group>"; };
 		F91EA24A2C3D12B7007489BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				A7C4A2A62F365F2B00AC6033 /* EditorWithToolbar.swift */,
 				A768AFC82C5C36090055519D /* NotScrollableEditorView.swift */,
 				A768AFCB2C5C37210055519D /* FixedSizeEditorView.swift */,
+				B76F396B2FB4619D00C6F32F /* EditorWithSwiftUIToolbar.swift */,
 			);
 			path = Editors;
 			sourceTree = "<group>";
@@ -189,6 +192,7 @@
 				F91EA2492C3D12B7007489BD /* Example_SwiftUIApp.swift in Sources */,
 				A768AFCC2C5C37210055519D /* FixedSizeEditorView.swift in Sources */,
 				A768AFC92C5C36090055519D /* NotScrollableEditorView.swift in Sources */,
+				B76F396D2FB4638200C6F32F /* EditorWithSwiftUIToolbar.swift in Sources */,
 				A7C4A2A72F365F2B00AC6033 /* EditorWithToolbar.swift in Sources */,
 				A768AFC72C5C35500055519D /* ScrollableEditorView.swift in Sources */,
 			);

--- a/Examples/Example SwiftUI/Example SwiftUI/Views/Editors/EditorWithSwiftUIToolbar.swift
+++ b/Examples/Example SwiftUI/Example SwiftUI/Views/Editors/EditorWithSwiftUIToolbar.swift
@@ -1,0 +1,174 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+//  EditorWithSwiftUIToolbar.swift
+//  InfomaniakRichHTMLEditor
+//
+//  Created by William Mead on 13/05/2026.
+//
+
+import SwiftUI
+import InfomaniakRichHTMLEditor
+
+// MARK: - SwiftUI toolbar view
+struct EditorSwiftUIToolbarContent: View {
+    @ObservedObject var textAttributes: TextAttributes
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 12) {
+                // Text formatting
+                EditorToolbarButton(
+                    systemImage: "bold",
+                    isActive: textAttributes.hasBold
+                ) {
+                    textAttributes.bold()
+                }
+                EditorToolbarButton(
+                    systemImage: "italic",
+                    isActive: textAttributes.hasItalic
+                ) {
+                    textAttributes.italic()
+                }
+                EditorToolbarButton(
+                    systemImage: "underline",
+                    isActive: textAttributes.hasUnderline
+                ) {
+                    textAttributes.underline()
+                }
+                EditorToolbarButton(
+                    systemImage: "strikethrough",
+                    isActive: textAttributes.hasStrikethrough
+                ) {
+                    textAttributes.strikethrough()
+                }
+                Divider().frame(height: 20)
+                // Lists
+                EditorToolbarButton(
+                    systemImage: "list.number",
+                    isActive: textAttributes.hasOrderedList
+                ) {
+                    textAttributes.orderedList()
+                }
+                EditorToolbarButton(
+                    systemImage: "list.bullet",
+                    isActive: textAttributes.hasUnorderedList
+                ) {
+                    textAttributes.unorderedList()
+                }
+                Divider().frame(height: 20)
+                // Indentation
+                EditorToolbarButton(
+                    systemImage: "decrease.indent",
+                    isActive: false
+                ) {
+                    textAttributes.outdent()
+                }
+                EditorToolbarButton(
+                    systemImage: "increase.indent",
+                    isActive: false
+                ) {
+                    textAttributes.indent()
+                }
+                Divider().frame(height: 20)
+                // Undo / Redo
+                EditorToolbarButton(
+                    systemImage: "arrow.uturn.backward",
+                    isActive: false
+                ) {
+                    textAttributes.undo()
+                }
+                EditorToolbarButton(
+                    systemImage: "arrow.uturn.forward",
+                    isActive: false
+                ) {
+                    textAttributes.redo()
+                }
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 8)
+        }
+        .scrollIndicators(.hidden)
+        .frame(height: 44)
+        .background(.ultraThinMaterial, in: .rect(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Toolbar button
+struct EditorToolbarButton: View {
+
+    let systemImage: String
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.body)
+                .frame(width: 36, height: 36)
+                .foregroundStyle(isActive ? Color.accentColor : .primary)
+                .background(isActive ? Color.accentColor.opacity(0.2) : .clear, in: .rect(cornerRadius: 12))
+        }
+    }
+
+}
+
+// MARK: - UIView wrapper for input accessory
+
+final class EditorSwiftUIToolbar: UIView {
+
+    private let hostingController: UIHostingController<EditorSwiftUIToolbarContent>
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: 44)
+    }
+
+    init(textAttributes: TextAttributes) {
+        hostingController = UIHostingController(rootView: EditorSwiftUIToolbarContent(textAttributes: textAttributes))
+        hostingController.view.backgroundColor = .clear
+
+        super.init(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
+        autoresizingMask = .flexibleWidth
+
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hostingController.view)
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hostingController.view.topAnchor.constraint(equalTo: topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: -
+struct EditorWithSwiftUIToolbar: View {
+    @State private var html = "<h1>EditorWithToolbar</h1><p>This editor <strong>has a toolbar</strong>. Focus the editor to reveal it. The toolbar can be scrolled horizontally.</p>"
+    @StateObject private var textAttributes = TextAttributes()
+
+    var body: some View {
+        RichHTMLEditor(html: $html, textAttributes: textAttributes)
+            .editorScrollable(true)
+            .editorInputAccessoryView(EditorSwiftUIToolbar(textAttributes: textAttributes))
+    }
+}
+
+#Preview {
+    EditorWithSwiftUIToolbar()
+}

--- a/Examples/Example SwiftUI/Example SwiftUI/Views/Editors/EditorWithSwiftUIToolbar.swift
+++ b/Examples/Example SwiftUI/Example SwiftUI/Views/Editors/EditorWithSwiftUIToolbar.swift
@@ -10,93 +10,60 @@
 //  KIND, either express or implied.  See the License for the
 //  specific language governing permissions and limitations
 //  under the License.
-//
-//  EditorWithSwiftUIToolbar.swift
-//  InfomaniakRichHTMLEditor
-//
-//  Created by William Mead on 13/05/2026.
-//
 
-import SwiftUI
 import InfomaniakRichHTMLEditor
+import SwiftUI
 
-// MARK: - SwiftUI toolbar view
 struct EditorSwiftUIToolbarContent: View {
     @ObservedObject var textAttributes: TextAttributes
 
     var body: some View {
         ScrollView(.horizontal) {
-            HStack(spacing: 12) {
-                // Text formatting
-                EditorToolbarButton(
-                    systemImage: "bold",
-                    isActive: textAttributes.hasBold
-                ) {
+            HStack(spacing: 4) {
+                EditorToolbarButton(systemImage: "bold", isActive: textAttributes.hasBold) {
                     textAttributes.bold()
                 }
-                EditorToolbarButton(
-                    systemImage: "italic",
-                    isActive: textAttributes.hasItalic
-                ) {
+                EditorToolbarButton(systemImage: "italic", isActive: textAttributes.hasItalic) {
                     textAttributes.italic()
                 }
-                EditorToolbarButton(
-                    systemImage: "underline",
-                    isActive: textAttributes.hasUnderline
-                ) {
+                EditorToolbarButton(systemImage: "underline", isActive: textAttributes.hasUnderline) {
                     textAttributes.underline()
                 }
-                EditorToolbarButton(
-                    systemImage: "strikethrough",
-                    isActive: textAttributes.hasStrikethrough
-                ) {
+                EditorToolbarButton(systemImage: "strikethrough", isActive: textAttributes.hasStrikethrough) {
                     textAttributes.strikethrough()
                 }
-                Divider().frame(height: 20)
-                // Lists
-                EditorToolbarButton(
-                    systemImage: "list.number",
-                    isActive: textAttributes.hasOrderedList
-                ) {
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "list.number", isActive: textAttributes.hasOrderedList) {
                     textAttributes.orderedList()
                 }
-                EditorToolbarButton(
-                    systemImage: "list.bullet",
-                    isActive: textAttributes.hasUnorderedList
-                ) {
+                EditorToolbarButton(systemImage: "list.bullet", isActive: textAttributes.hasUnorderedList) {
                     textAttributes.unorderedList()
                 }
-                Divider().frame(height: 20)
-                // Indentation
-                EditorToolbarButton(
-                    systemImage: "decrease.indent",
-                    isActive: false
-                ) {
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "decrease.indent", isActive: false) {
                     textAttributes.outdent()
                 }
-                EditorToolbarButton(
-                    systemImage: "increase.indent",
-                    isActive: false
-                ) {
+                EditorToolbarButton(systemImage: "increase.indent", isActive: false) {
                     textAttributes.indent()
                 }
-                Divider().frame(height: 20)
-                // Undo / Redo
-                EditorToolbarButton(
-                    systemImage: "arrow.uturn.backward",
-                    isActive: false
-                ) {
+
+                Divider()
+                    .frame(height: 20)
+
+                EditorToolbarButton(systemImage: "arrow.uturn.backward", isActive: false) {
                     textAttributes.undo()
                 }
-                EditorToolbarButton(
-                    systemImage: "arrow.uturn.forward",
-                    isActive: false
-                ) {
+                EditorToolbarButton(systemImage: "arrow.uturn.forward", isActive: false) {
                     textAttributes.redo()
                 }
             }
-            .fixedSize(horizontal: true, vertical: false)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, 4)
         }
         .scrollIndicators(.hidden)
         .frame(height: 44)
@@ -106,8 +73,8 @@ struct EditorSwiftUIToolbarContent: View {
 }
 
 // MARK: - Toolbar button
-struct EditorToolbarButton: View {
 
+struct EditorToolbarButton: View {
     let systemImage: String
     let isActive: Bool
     let action: () -> Void
@@ -121,13 +88,11 @@ struct EditorToolbarButton: View {
                 .background(isActive ? Color.accentColor.opacity(0.2) : .clear, in: .rect(cornerRadius: 12))
         }
     }
-
 }
 
 // MARK: - UIView wrapper for input accessory
 
 final class EditorSwiftUIToolbar: UIView {
-
     private let hostingController: UIHostingController<EditorSwiftUIToolbarContent>
 
     override var intrinsicContentSize: CGSize {
@@ -137,11 +102,11 @@ final class EditorSwiftUIToolbar: UIView {
     init(textAttributes: TextAttributes) {
         hostingController = UIHostingController(rootView: EditorSwiftUIToolbarContent(textAttributes: textAttributes))
         hostingController.view.backgroundColor = .clear
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
         super.init(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
         autoresizingMask = .flexibleWidth
 
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         addSubview(hostingController.view)
         NSLayoutConstraint.activate([
             hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -151,13 +116,14 @@ final class EditorSwiftUIToolbar: UIView {
         ])
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
 }
 
 // MARK: -
+
 struct EditorWithSwiftUIToolbar: View {
     @State private var html = "<h1>EditorWithToolbar</h1><p>This editor <strong>has a toolbar</strong>. Focus the editor to reveal it. The toolbar can be scrolled horizontally.</p>"
     @StateObject private var textAttributes = TextAttributes()

--- a/Examples/Example SwiftUI/Example SwiftUI/Views/RootView.swift
+++ b/Examples/Example SwiftUI/Example SwiftUI/Views/RootView.swift
@@ -18,6 +18,7 @@ enum EditorState: String, CaseIterable {
     case notScrollable = "Not Scrollable"
     case fixedSize = "Fixed Size"
     case editorWithToolbar = "Editor with Toolbar"
+    case editorWithSwiftUIToolbar = "Editor with SwiftUI Toolbar"
 }
 
 struct RootView: View {
@@ -35,6 +36,8 @@ struct RootView: View {
                     FixedSizeEditorView()
                 case .editorWithToolbar:
                     EditorWithToolbar()
+                case .editorWithSwiftUIToolbar:
+                    EditorWithSwiftUIToolbar()
                 }
             }
             .navigationTitle("Infomaniak - RichHTMLEditor (SwiftUI)")


### PR DESCRIPTION
Added an example of the editor using a SwiftUI toolbar via UIHostingController. For natif SwiftUI apps this approach seems cleaner.